### PR TITLE
Bit flag QoS validation as described in Normative Statement Number # MQTT-3.3.1-4

### DIFF
--- a/src/pre_connect.erl
+++ b/src/pre_connect.erl
@@ -22,7 +22,11 @@ get_msg_type(<<1:4, 0:1, 0:2, 0:1, _RemainingBin>> = Bin) ->
     {ok, connect, Bin};
 get_msg_type(<<2:4, 0:1, 0:2, 0:1, _RemainingBin>> = Bin) -> 
     {ok, connack, Bin};
-get_msg_type(<<3:4, _Dup:1, _QoS:2, _Retain:1, _RemainingBin>> = Bin) -> 
+get_msg_type(<<3:4, _Dup:1, 0:2, _Retain:1, _RemainingBin>> = Bin) -> 
+    {ok, publish, Bin};
+get_msg_type(<<3:4, _Dup:1, 1:2, _Retain:1, _RemainingBin>> = Bin) -> 
+    {ok, publish, Bin};
+get_msg_type(<<3:4, _Dup:1, 2:2, _Retain:1, _RemainingBin>> = Bin) -> 
     {ok, publish, Bin};
 get_msg_type(<<4:4, 0:1, 0:2, 0:1, _RemainingBin>> = Bin) -> 
     {ok, puback, Bin};

--- a/test/pre_connect_tests.erl
+++ b/test/pre_connect_tests.erl
@@ -114,88 +114,88 @@ invalidate_msg_type_test() ->
 	      , #testdata{msgtype = 0, dup = 0, qos = 3, retain = 0}
 	      , #testdata{msgtype = 0, dup = 0, qos = 0, retain = 1}
                 %%% Invalid Type = 15
-		#testdata{msgtype = 15, dup = 0, qos = 0, retain = 0}
+	      , #testdata{msgtype = 15, dup = 0, qos = 0, retain = 0}
 	      , #testdata{msgtype = 15, dup = 1, qos = 0, retain = 0}
 	      , #testdata{msgtype = 15, dup = 0, qos = 1, retain = 0}
 	      , #testdata{msgtype = 15, dup = 0, qos = 2, retain = 0}
 	      , #testdata{msgtype = 15, dup = 0, qos = 3, retain = 0}
 	      , #testdata{msgtype = 15, dup = 0, qos = 0, retain = 1}
                 %%% Type = 1 (CONNECT)
-		#testdata{msgtype = 1, dup = 1, qos = 0, retain = 0}
+	      , #testdata{msgtype = 1, dup = 1, qos = 0, retain = 0}
 	      , #testdata{msgtype = 1, dup = 0, qos = 1, retain = 0}
 	      , #testdata{msgtype = 1, dup = 0, qos = 2, retain = 0}
 	      , #testdata{msgtype = 1, dup = 0, qos = 3, retain = 0}
 	      , #testdata{msgtype = 1, dup = 0, qos = 0, retain = 1}
                 %%% Type = 2 (CONNACK)
-		#testdata{msgtype = 2, dup = 1, qos = 0, retain = 0}
+	      , #testdata{msgtype = 2, dup = 1, qos = 0, retain = 0}
 	      , #testdata{msgtype = 2, dup = 0, qos = 1, retain = 0}
 	      , #testdata{msgtype = 2, dup = 0, qos = 2, retain = 0}
 	      , #testdata{msgtype = 2, dup = 0, qos = 3, retain = 0}
 	      , #testdata{msgtype = 2, dup = 0, qos = 0, retain = 1}
                 %%% Type = 3 (PUBLISH)
-	        %%% , #testdata{msgtype = 3, dup = 0, qos = 3, retain = 0}
+	      , #testdata{msgtype = 3, dup = 0, qos = 3, retain = 0}
                 %%% Type = 4 (PUBACK)
-		#testdata{msgtype = 4, dup = 1, qos = 0, retain = 0}
+	      , #testdata{msgtype = 4, dup = 1, qos = 0, retain = 0}
 	      , #testdata{msgtype = 4, dup = 0, qos = 1, retain = 0}
 	      , #testdata{msgtype = 4, dup = 0, qos = 2, retain = 0}
 	      , #testdata{msgtype = 4, dup = 0, qos = 3, retain = 0}
 	      , #testdata{msgtype = 4, dup = 0, qos = 0, retain = 1}
                 %%% Type = 5 (PUBREC)
-		#testdata{msgtype = 5, dup = 1, qos = 0, retain = 0}
+	      , #testdata{msgtype = 5, dup = 1, qos = 0, retain = 0}
 	      , #testdata{msgtype = 5, dup = 0, qos = 1, retain = 0}
 	      , #testdata{msgtype = 5, dup = 0, qos = 2, retain = 0}
 	      , #testdata{msgtype = 5, dup = 0, qos = 3, retain = 0}
 	      , #testdata{msgtype = 5, dup = 0, qos = 0, retain = 1}
                 %%% Type = 6 (PUBREL)
-		#testdata{msgtype = 6, dup = 1, qos = 0, retain = 0}
+	      , #testdata{msgtype = 6, dup = 1, qos = 0, retain = 0}
 	      , #testdata{msgtype = 6, dup = 0, qos = 0, retain = 0}
 	      , #testdata{msgtype = 6, dup = 0, qos = 2, retain = 0}
 	      , #testdata{msgtype = 6, dup = 0, qos = 3, retain = 0}
 	      , #testdata{msgtype = 6, dup = 0, qos = 0, retain = 1}
                 %%% Type = 7 (PUBCOMP)
-		#testdata{msgtype = 7, dup = 1, qos = 0, retain = 0}
+	      , #testdata{msgtype = 7, dup = 1, qos = 0, retain = 0}
 	      , #testdata{msgtype = 7, dup = 0, qos = 1, retain = 0}
 	      , #testdata{msgtype = 7, dup = 0, qos = 2, retain = 0}
 	      , #testdata{msgtype = 7, dup = 0, qos = 3, retain = 0}
 	      , #testdata{msgtype = 7, dup = 0, qos = 0, retain = 1}
                 %%% Type = 8 (SUBSCRIBE)
-		#testdata{msgtype = 8, dup = 1, qos = 0, retain = 0}
+	      , #testdata{msgtype = 8, dup = 1, qos = 0, retain = 0}
 	      , #testdata{msgtype = 8, dup = 0, qos = 0, retain = 0}
 	      , #testdata{msgtype = 8, dup = 0, qos = 2, retain = 0}
 	      , #testdata{msgtype = 8, dup = 0, qos = 3, retain = 0}
 	      , #testdata{msgtype = 8, dup = 0, qos = 0, retain = 1}
                 %%% Type = 9 (SUBACK)
-		#testdata{msgtype = 9, dup = 1, qos = 0, retain = 0}
+	      , #testdata{msgtype = 9, dup = 1, qos = 0, retain = 0}
 	      , #testdata{msgtype = 9, dup = 0, qos = 1, retain = 0}
 	      , #testdata{msgtype = 9, dup = 0, qos = 2, retain = 0}
 	      , #testdata{msgtype = 9, dup = 0, qos = 3, retain = 0}
 	      , #testdata{msgtype = 9, dup = 0, qos = 0, retain = 1}
                 %%% Type = 10 (UNSUBSCRIBE)
-		#testdata{msgtype = 10, dup = 1, qos = 0, retain = 0}
+	      , #testdata{msgtype = 10, dup = 1, qos = 0, retain = 0}
 	      , #testdata{msgtype = 10, dup = 0, qos = 0, retain = 0}
 	      , #testdata{msgtype = 10, dup = 0, qos = 2, retain = 0}
 	      , #testdata{msgtype = 10, dup = 0, qos = 3, retain = 0}
 	      , #testdata{msgtype = 10, dup = 0, qos = 0, retain = 1}
                 %%% Type = 11 (UNSUBACK)
-		#testdata{msgtype = 11, dup = 1, qos = 0, retain = 0}
+	      , #testdata{msgtype = 11, dup = 1, qos = 0, retain = 0}
 	      , #testdata{msgtype = 11, dup = 0, qos = 1, retain = 0}
 	      , #testdata{msgtype = 11, dup = 0, qos = 2, retain = 0}
 	      , #testdata{msgtype = 11, dup = 0, qos = 3, retain = 0}
 	      , #testdata{msgtype = 11, dup = 0, qos = 0, retain = 1}
                 %%% Type = 12 (PINGREQ)
-		#testdata{msgtype = 12, dup = 1, qos = 0, retain = 0}
+	      , #testdata{msgtype = 12, dup = 1, qos = 0, retain = 0}
 	      , #testdata{msgtype = 12, dup = 0, qos = 1, retain = 0}
 	      , #testdata{msgtype = 12, dup = 0, qos = 2, retain = 0}
 	      , #testdata{msgtype = 12, dup = 0, qos = 3, retain = 0}
 	      , #testdata{msgtype = 12, dup = 0, qos = 0, retain = 1}
                 %%% Type = 13 (PINGRESP)
-		#testdata{msgtype = 13, dup = 1, qos = 0, retain = 0}
+	      , #testdata{msgtype = 13, dup = 1, qos = 0, retain = 0}
 	      , #testdata{msgtype = 13, dup = 0, qos = 1, retain = 0}
 	      , #testdata{msgtype = 13, dup = 0, qos = 2, retain = 0}
 	      , #testdata{msgtype = 13, dup = 0, qos = 3, retain = 0}
 	      , #testdata{msgtype = 13, dup = 0, qos = 0, retain = 1}
                 %%% Type = 14 (DISCONNECT)
-		#testdata{msgtype = 14, dup = 1, qos = 0, retain = 0}
+	      , #testdata{msgtype = 14, dup = 1, qos = 0, retain = 0}
 	      , #testdata{msgtype = 14, dup = 0, qos = 1, retain = 0}
 	      , #testdata{msgtype = 14, dup = 0, qos = 2, retain = 0}
 	      , #testdata{msgtype = 14, dup = 0, qos = 3, retain = 0}


### PR DESCRIPTION
To comply with the Normative Statement Number # MQTT-3.3.1-4, described in the Appendix B,page number 73 of the specification, I have added code to validate value of QoS bits for a message of type PUBLISH. Also updated tests, related to the same implementation. Note that its a partial implementation for the requirement. I am just validating the value of the QoS bits of PUBLISH message. If found invalid, the "get_msg_type" function will return error. The intended normative statement requires to close the Network Connection, which I have not addressed in this function.