### PR TITLE
Feature : get_bit_flags

### DIFF
--- a/src/pre_connect.erl
+++ b/src/pre_connect.erl
@@ -10,6 +10,7 @@
 %% API
 -export([
 	 get_msg_type/1,
+	 get_bit_flags/1,
 	 validate_remaining_length/1
 	]).
 -define(MAX_LENGTH, 268435455). % Maximum allowed length of the topic.
@@ -54,6 +55,16 @@ get_msg_type(_Bin) ->
     {error, invalid_fb, _Bin}.
     
 %%===================================================================
+%% Get bit flags from the fixed header.
+%% Eventually, this method will be used to extract bit-flags from the 
+%% message type = PUBLISH, because for rest of the message types,
+%% their bit-flags are constant.
+get_bit_flags(<<_Type:4, Dup:1, QoS:2, Retain:1, _RemainingBin>> = Bin) ->
+    {ok, Dup, QoS, Retain, Bin}.
+    
+
+
+%%===================================================================
 %% Decode remaining length from the RestBin (RestBin does not contain
 %% FirstByte). If value of the remaining length field is correct,
 %% return rest of the binary.  Rest of the binary returned will
@@ -75,6 +86,6 @@ validate_remaining_length(<<1:1, Len:7, Rest/binary>>, RLength, Multiplier) ->
 validate_remaining_length(<<0:1, Len:7, Rest/binary>>, RLength, Multiplier)
   when ((RLength + Len * Multiplier) =:= size(Rest)) ->
     {ok, Rest};
-%% Rest of the message is having invalid lenght.
+%% Rest of the message is having invalid length.
 validate_remaining_length(_, _, _) ->
     {error, invalid_rl}.

--- a/test/pre_connect_tests.erl
+++ b/test/pre_connect_tests.erl
@@ -206,3 +206,10 @@ invalidate_msg_type_test() ->
 assert_for_invalid_msg_type(#testdata{msgtype = MsgType, dup = Dup, qos = QoS, retain = Retain}) ->
     Bin = <<MsgType:4, Dup:1, QoS:2, Retain:1, 100:8>>,
     ?assertEqual({error, invalid_fb, Bin}, pre_connect:get_msg_type(Bin)).
+
+%%==================================================================
+%% Test get_bit_flags
+
+get_bit_flags_test() ->
+    Bin = <<3:4, 0:1, 0:2, 0:1, 100:8>>,
+    ?assertEqual({ok, 0, 0, 0, Bin}, pre_connect:get_bit_flags(Bin)).


### PR DESCRIPTION
Added function to get bit flags from the passed binary. Eventually, this function will be used to extract bit flags from the message of type PUBLISH, as for other message types bit-flags are constant and readily specified in MQTTv3.1.1 specification. Also added is a test, which I think is sufficient.