### PR TITLE
Rename functions

### DIFF
--- a/src/pre_processor.erl
+++ b/src/pre_processor.erl
@@ -1,27 +1,27 @@
 %%%-------------------------------------------------------------------
 %%% @author kuldeep 
 %%% @copyright (C) 2016, kuldeep
-%%% @doc
+%%% @doc 
 %%%
 %%% @end Created : 13 April 2016 by kuldeep
 %%% -------------------------------------------------------------------
 -module(pre_processor).
 -include("../include/yams_lib.hrl").
 %% API
--export([compile_packet/1]).
+-export([interprete_packet/1]).
 %% Macro
 -define(MAX_LENGTH, 268435455). % Maximum allowed length of the topic.
 
 %%===================================================================
--spec compile_packet(packet_binary()) -> 
+-spec interprete_packet(packet_binary()) -> 
 			    remaining_length_ok() 
 			   |remaining_length_error()
 			   |packet_type_error().
 				
-compile_packet(Binary) ->
-    compile_remaining_length(compile_packet_type(Binary)).
+interprete_packet(Binary) ->
+    interprete_remaining_length(interprete_packet_type(Binary)).
 %%===================================================================
-%% Roughly speaking, compile_packet_type/1 behaves like a compiler-front-end.
+%% Roughly speaking, interprete_packet_type/1 behaves like an interpreter-front-end.
 %% It scans (creates tokens from the) first byte of the control packet. 
 %% And parses (analyzes) the tokens and determines their validity.
 %% As an output the function returns following.
@@ -41,43 +41,43 @@ compile_packet(Binary) ->
 			     ,binary()}.
 
 
--spec compile_packet_type(packet_binary()) -> 
+-spec interprete_packet_type(packet_binary()) -> 
 				 packet_type_ok()
 				|packet_type_error().
 
-compile_packet_type(<<1:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<1:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = connect, dup = 0, qos = 0, retain = 0}, RemainingBin};
-compile_packet_type(<<2:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<2:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = connack, dup = 0, qos = 0, retain = 0}, RemainingBin};
-compile_packet_type(<<3:4, Dup:1, 0:2, Retain:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<3:4, Dup:1, 0:2, Retain:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = publish, dup = Dup, qos = 0, retain = Retain}, RemainingBin};
-compile_packet_type(<<3:4, Dup:1, 1:2, Retain:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<3:4, Dup:1, 1:2, Retain:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = publish, dup = Dup, qos = 1, retain = Retain}, RemainingBin};
-compile_packet_type(<<3:4, Dup:1, 2:2, Retain:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<3:4, Dup:1, 2:2, Retain:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = publish, dup = Dup, qos = 2, retain = Retain}, RemainingBin};
-compile_packet_type(<<4:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<4:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = puback, dup = 0, qos = 0, retain = 0}, RemainingBin};
-compile_packet_type(<<5:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<5:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = pubrec, dup = 0, qos = 0, retain = 0}, RemainingBin};
-compile_packet_type(<<6:4, 0:1, 1:2, 0:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<6:4, 0:1, 1:2, 0:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = pubrel, dup = 0, qos = 1, retain = 0}, RemainingBin};
-compile_packet_type(<<7:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<7:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = pubcomp, dup = 0, qos = 0, retain = 0}, RemainingBin};
-compile_packet_type(<<8:4, 0:1, 1:2, 0:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<8:4, 0:1, 1:2, 0:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = subscribe, dup = 0, qos = 1, retain = 0}, RemainingBin};
-compile_packet_type(<<9:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<9:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = suback, dup = 0, qos = 0, retain = 0}, RemainingBin};
-compile_packet_type(<<10:4, 0:1, 1:2, 0:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<10:4, 0:1, 1:2, 0:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = unsubscribe, dup = 0, qos = 1, retain = 0}, RemainingBin};
-compile_packet_type(<<11:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<11:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = unsuback, dup = 0, qos = 0, retain = 0}, RemainingBin};
-compile_packet_type(<<12:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<12:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = pingreq, dup = 0, qos = 0, retain = 0}, RemainingBin};
-compile_packet_type(<<13:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<13:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = pingresp, dup = 0, qos = 0, retain = 0}, RemainingBin};
-compile_packet_type(<<14:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
+interprete_packet_type(<<14:4, 0:1, 0:2, 0:1, RemainingBin/binary>>) ->
     {ok, #packet_type{msgtype = disconnect, dup = 0, qos = 0, retain = 0}, RemainingBin};
-compile_packet_type(OtherBin) ->
+interprete_packet_type(OtherBin) ->
     {error, invalid_fb, OtherBin}.
     
 %%===================================================================
@@ -85,14 +85,14 @@ compile_packet_type(OtherBin) ->
 %% 1. Remaining length of the packet, which I call it - var_load
 %% 2. var_load (= variable header + payload)
 %%===================================================================
--spec compile_remaining_length(packet_type_ok()
+-spec interprete_remaining_length(packet_type_ok()
 			      |packet_type_error())->
 				      remaining_length_ok() 
 				     |remaining_length_error()
 				     |packet_type_error().
-compile_remaining_length({ok, PacketType, RemainingBin}) ->
-    compile_remaining_length({PacketType, RemainingBin}, 0, 1);
-compile_remaining_length({error, invalid_fb, OtherBin}) ->
+interprete_remaining_length({ok, PacketType, RemainingBin}) ->
+    interprete_remaining_length({PacketType, RemainingBin}, 0, 1);
+interprete_remaining_length({error, invalid_fb, OtherBin}) ->
     {error, invalid_fb, OtherBin}.
 
 %%==============================================
@@ -112,20 +112,20 @@ compile_remaining_length({error, invalid_fb, OtherBin}) ->
 				  ,remaining_length()
 				  ,binary()}.
 
--spec compile_remaining_length({packet_type(),binary()},non_neg_integer(),pos_integer()) -> 
+-spec interprete_remaining_length({packet_type(),binary()},non_neg_integer(),pos_integer()) -> 
 				      remaining_length_ok()
 				     |remaining_length_error().
 				    
-compile_remaining_length(TypeCompiledPacket, _RemainingLength, Multiplier)
+interprete_remaining_length(TypeInterpretedPacket, _RemainingLength, Multiplier)
   when (Multiplier > 128 * 128 * 128) ->
-    {error, remaining_length_exceeds_max_length, TypeCompiledPacket};
+    {error, remaining_length_exceeds_max_length, TypeInterpretedPacket};
 %% Calculate the remaining length value:
 %% Recurse if the value of the first bit is 1.
-compile_remaining_length({PacketType, <<1:1, Len:7, Rest/binary>>}, RemainingLength, Multiplier) ->
-    compile_remaining_length({PacketType, Rest}, RemainingLength + Len * Multiplier, Multiplier * 128);
+interprete_remaining_length({PacketType, <<1:1, Len:7, Rest/binary>>}, RemainingLength, Multiplier) ->
+    interprete_remaining_length({PacketType, Rest}, RemainingLength + Len * Multiplier, Multiplier * 128);
 %% Calculate Value of the remaining length :
 %% Return if the value of the first bit is 0.
-compile_remaining_length({PacketType, <<0:1, Len:7, VarLoad/binary>>}, RemainingLength, Multiplier) ->
+interprete_remaining_length({PacketType, <<0:1, Len:7, VarLoad/binary>>}, RemainingLength, Multiplier) ->
     RemLen = RemainingLength + (Len * Multiplier),
     case (RemLen =:= size(VarLoad)) of
 	true -> 

--- a/test/pre_processor_test.erl
+++ b/test/pre_processor_test.erl
@@ -17,92 +17,92 @@
 %% CONNECT Test
 get_msg_type_for_connect_test() ->
     ?assertEqual({ok, #packet_type{msgtype = connect, dup = 0, qos = 0, retain = 0}, <<100>>},
-		  (pre_processor:compile_packet_type(<<1:4, 0:1, 0:2, 0:1, 100:8>>))).
+		  (pre_processor:interprete_packet_type(<<1:4, 0:1, 0:2, 0:1, 100:8>>))).
 
 %% CONNACK Test
 get_msg_type_for_connack_test() ->
     ?assertEqual({ok, #packet_type{msgtype = connack, dup = 0, qos = 0, retain = 0}, <<2>>},
-		  (pre_processor:compile_packet_type(<<2:4, 0:1, 0:2, 0:1, 2:8>>))).
+		  (pre_processor:interprete_packet_type(<<2:4, 0:1, 0:2, 0:1, 2:8>>))).
 
 %% PUBLISH Test
 get_msg_type_for_publish_test() ->
     ?assertEqual({ok, #packet_type{msgtype = publish, dup = 0, qos = 0, retain = 0}, <<100>>},
-		  (pre_processor:compile_packet_type(<<3:4, 0:1, 0:2, 0:1, 100:8>>))).
+		  (pre_processor:interprete_packet_type(<<3:4, 0:1, 0:2, 0:1, 100:8>>))).
 
 %% PUBLISH Test with DUP flag = 1
 get_msg_type_for_publish_with_dup_flag_value_1_test() ->
     ?assertEqual({ok, #packet_type{msgtype = publish, dup = 1, qos = 0, retain = 0}, <<100>>},
-		  (pre_processor:compile_packet_type(<<3:4, 1:1, 0:2, 0:1, 100:8>>))).
+		  (pre_processor:interprete_packet_type(<<3:4, 1:1, 0:2, 0:1, 100:8>>))).
 
 %% PUBLISH Test with Qos flag = 1
 get_msg_type_for_publish_with_qos_flag_value_1_test() ->
     ?assertEqual({ok, #packet_type{msgtype = publish, dup = 1, qos = 1, retain = 0}, <<100>>},
-		  (pre_processor:compile_packet_type(<<3:4, 1:1, 1:2, 0:1, 100:8>>))).
+		  (pre_processor:interprete_packet_type(<<3:4, 1:1, 1:2, 0:1, 100:8>>))).
 
 %% PUBLISH Test with Qos flag = 2
 get_msg_type_for_publish_with_qos_flag_value_2_test() ->
     ?assertEqual({ok, #packet_type{msgtype = publish, dup = 0, qos = 2, retain = 0}, <<100>>},
-		  (pre_processor:compile_packet_type(<<3:4, 0:1, 2:2, 0:1, 100:8>>))).
+		  (pre_processor:interprete_packet_type(<<3:4, 0:1, 2:2, 0:1, 100:8>>))).
 
 %% PUBLISH Test with Retain flag = 1
 get_msg_type_for_publish_with_retain_flag_value_1_test() ->
     ?assertEqual({ok, #packet_type{msgtype = publish, dup = 0, qos = 2, retain = 1}, <<100>>},
-		  (pre_processor:compile_packet_type(<<3:4, 0:1, 2:2, 1:1, 100:8>>))).
+		  (pre_processor:interprete_packet_type(<<3:4, 0:1, 2:2, 1:1, 100:8>>))).
 
 %% PUBACK Test
 get_msg_type_for_puback_test() ->
     ?assertEqual({ok, #packet_type{msgtype = puback, dup = 0, qos = 0, retain = 0}, <<2>>},
-		  (pre_processor:compile_packet_type(<<4:4, 0:1, 0:2, 0:1, 2:8>>))).
+		  (pre_processor:interprete_packet_type(<<4:4, 0:1, 0:2, 0:1, 2:8>>))).
 
 %% PUBREC Test
 get_msg_type_for_pubrec_test() ->
     ?assertEqual({ok, #packet_type{msgtype = pubrec, dup = 0, qos = 0, retain = 0}, <<2>>},
-		  (pre_processor:compile_packet_type(<<5:4, 0:1, 0:2, 0:1, 2:8>>))).
+		  (pre_processor:interprete_packet_type(<<5:4, 0:1, 0:2, 0:1, 2:8>>))).
 
 %% PUBREL Test
 get_msg_type_for_pubrel_test() ->
     ?assertEqual({ok, #packet_type{msgtype = pubrel, dup = 0, qos = 1, retain = 0}, <<2>>},
-		  (pre_processor:compile_packet_type(<<6:4, 0:1, 1:2, 0:1, 2:8>>))).
+		  (pre_processor:interprete_packet_type(<<6:4, 0:1, 1:2, 0:1, 2:8>>))).
 
 %% PUBCOMP Test
 get_msg_type_for_pubcomp_test() ->
     ?assertEqual({ok, #packet_type{msgtype = pubcomp, dup = 0, qos = 0, retain = 0}, <<2>>},
-		  (pre_processor:compile_packet_type(<<7:4, 0:1, 0:2, 0:1, 2:8>>))).
+		  (pre_processor:interprete_packet_type(<<7:4, 0:1, 0:2, 0:1, 2:8>>))).
 
 %% SUBSCRIBE Test
 get_msg_type_for_subscribe_test() ->
     ?assertEqual({ok, #packet_type{msgtype = subscribe, dup = 0, qos = 1, retain = 0}, <<100>>},
-		  (pre_processor:compile_packet_type(<<8:4, 0:1, 1:2, 0:1, 100:8>>))).
+		  (pre_processor:interprete_packet_type(<<8:4, 0:1, 1:2, 0:1, 100:8>>))).
 
 %% SUBACK Test
 get_msg_type_for_suback_test() ->
     ?assertEqual({ok, #packet_type{msgtype = suback, dup = 0, qos = 0, retain = 0}, <<100>>},
-		  (pre_processor:compile_packet_type(<<9:4, 0:1, 0:2, 0:1, 100:8>>))).
+		  (pre_processor:interprete_packet_type(<<9:4, 0:1, 0:2, 0:1, 100:8>>))).
 
 %% UNSUBSCRIBE Test
 get_msg_type_for_unsubscribe_test() ->
     ?assertEqual({ok, #packet_type{msgtype = unsubscribe, dup = 0, qos = 1, retain = 0}, <<100>>},
-		  (pre_processor:compile_packet_type(<<10:4, 0:1, 1:2, 0:1, 100:8>>))).
+		  (pre_processor:interprete_packet_type(<<10:4, 0:1, 1:2, 0:1, 100:8>>))).
 
 %% UNSUBACK Test
 get_msg_type_for_unsuback_test() ->
     ?assertEqual({ok, #packet_type{msgtype = unsuback, dup = 0, qos = 0, retain = 0}, <<2>>},
-		  (pre_processor:compile_packet_type(<<11:4, 0:1, 0:2, 0:1, 2:8>>))).
+		  (pre_processor:interprete_packet_type(<<11:4, 0:1, 0:2, 0:1, 2:8>>))).
 
 %% PINGREQ Test
 get_msg_type_for_pingreq_test() ->
     ?assertEqual({ok, #packet_type{msgtype = pingreq, dup = 0, qos = 0, retain = 0}, <<0>>},
-		  (pre_processor:compile_packet_type(<<12:4, 0:1, 0:2, 0:1, 0:8>>))).
+		  (pre_processor:interprete_packet_type(<<12:4, 0:1, 0:2, 0:1, 0:8>>))).
 
 %% pingresp Test
 get_msg_type_for_pingresp_test() ->
     ?assertEqual({ok, #packet_type{msgtype = pingresp, dup = 0, qos = 0, retain = 0}, <<0>>},
-		  (pre_processor:compile_packet_type(<<13:4, 0:1, 0:2, 0:1, 0:8>>))).
+		  (pre_processor:interprete_packet_type(<<13:4, 0:1, 0:2, 0:1, 0:8>>))).
 
 %% DISCONNECT Test
 get_msg_type_for_disconnect_test() ->
     ?assertEqual({ok, #packet_type{msgtype = disconnect, dup = 0, qos = 0, retain = 0}, <<0>>},
-		  (pre_processor:compile_packet_type(<<14:4, 0:1, 0:2, 0:1, 0:8>>))).
+		  (pre_processor:interprete_packet_type(<<14:4, 0:1, 0:2, 0:1, 0:8>>))).
 
 %% Test Invalid values
 get_test_data() ->
@@ -205,66 +205,66 @@ get_test_data() ->
 invalid_packet_type_test_() ->
     TestData = get_test_data(),
     [?_assertEqual({error, invalid_fb, <<MsgType:4, Dup:1, QoS:2, Retain:1, 100:8>>}, 
-		  (pre_processor:compile_packet_type(<<MsgType:4, Dup:1, QoS:2, Retain:1, 100:8>>)))
+		  (pre_processor:interprete_packet_type(<<MsgType:4, Dup:1, QoS:2, Retain:1, 100:8>>)))
      || #testdata{msgtype = MsgType, dup = Dup, qos = QoS, retain = Retain} <- TestData ].
 
 %%==========================================================================
-%% Pass result of invalid packet type to the compile_remaining_length function.
-compile_remaining_length_when_packetype_has_error_test_() ->
+%% Pass result of invalid packet type to the interprete_remaining_length function.
+interprete_remaining_length_when_packetype_has_error_test_() ->
     TestData = get_test_data(),
     [?_assertEqual({error, invalid_fb, <<MsgType:4, Dup:1, QoS:2, Retain:1, 100:8>>}, 
-		  (pre_processor:compile_remaining_length(pre_processor:compile_packet_type(<<MsgType:4, Dup:1, QoS:2, Retain:1, 100:8>>))))
+		  (pre_processor:interprete_remaining_length(pre_processor:interprete_packet_type(<<MsgType:4, Dup:1, QoS:2, Retain:1, 100:8>>))))
      || #testdata{msgtype = MsgType, dup = Dup, qos = QoS, retain = Retain} <- TestData ].
 
-%% compile_remaining_length_test - when remaining binary is too short
-compile_remaining_length_when_remaining_binary_is_too_short_test() ->
+%% interprete_remaining_length_test - when remaining binary is too short
+interprete_remaining_length_when_remaining_binary_is_too_short_test() ->
     ?assertEqual({error, remaining_length_value_unequal_to_the_actual_length, {packet_type,connect,0,0,0}, 1, <<>>},
-		 (pre_processor:compile_remaining_length(pre_processor:compile_packet_type(<<1:4, 0:4, 1:8>>)))).
+		 (pre_processor:interprete_remaining_length(pre_processor:interprete_packet_type(<<1:4, 0:4, 1:8>>)))).
 
-%% compile_remaining_length_test - when remaining binary is too long
-compile_remaining_length_when_remaining_binary_is_too_long_test() ->
+%% interprete_remaining_length_test - when remaining binary is too long
+interprete_remaining_length_when_remaining_binary_is_too_long_test() ->
     ?assertEqual({error, remaining_length_value_unequal_to_the_actual_length, {packet_type,connect,0,0,0}, 1, <<100:16>>},
-		 (pre_processor:compile_remaining_length(pre_processor:compile_packet_type(<<1:4, 0:4, 1:8, 100:16>>)))).
+		 (pre_processor:interprete_remaining_length(pre_processor:interprete_packet_type(<<1:4, 0:4, 1:8, 100:16>>)))).
 
-%% compile_remaining_length_test - lower limit of the first byte of the remaining length.
-compile_remaining_length_0_test() ->
+%% interprete_remaining_length_test - lower limit of the first byte of the remaining length.
+interprete_remaining_length_0_test() ->
     ?assertEqual({ok, #packet_type{msgtype = connect, dup =0, qos = 0, retain = 0}, 0, <<>>},
-		 (pre_processor:compile_remaining_length(pre_processor:compile_packet_type(<<1:4, 0:4, 0:8>>)))).
+		 (pre_processor:interprete_remaining_length(pre_processor:interprete_packet_type(<<1:4, 0:4, 0:8>>)))).
 
-%% compile_remaining_length_test - where remaining length is 2 bytes.
-compile_remaining_length_1_test() ->
+%% interprete_remaining_length_test - where remaining length is 2 bytes.
+interprete_remaining_length_1_test() ->
     ?assertEqual({ok, #packet_type{msgtype = connect, dup =0, qos = 0, retain = 0}, 2, <<100:16>>},
-		 (pre_processor:compile_remaining_length(pre_processor:compile_packet_type(<<1:4, 0:4, 2:8, 100:16>>)))).
-%% compile_remaining_length_test - upper limit of the first byte of the remaining length.
-compile_remaining_length_127_test() ->
+		 (pre_processor:interprete_remaining_length(pre_processor:interprete_packet_type(<<1:4, 0:4, 2:8, 100:16>>)))).
+%% interprete_remaining_length_test - upper limit of the first byte of the remaining length.
+interprete_remaining_length_127_test() ->
     ?assertEqual({ok, #packet_type{msgtype = connect, dup =0, qos = 0, retain = 0}, 127, <<100:1016>>},
-		 (pre_processor:compile_remaining_length(pre_processor:compile_packet_type(<<1:4, 0:4, 127:8, 100:1016>>)))).
+		 (pre_processor:interprete_remaining_length(pre_processor:interprete_packet_type(<<1:4, 0:4, 127:8, 100:1016>>)))).
 
-%% compile_remaining_length_test - lower limit of the second byte of the remaining length.
-compile_remaining_length_128_test() ->
+%% interprete_remaining_length_test - lower limit of the second byte of the remaining length.
+interprete_remaining_length_128_test() ->
     ?assertEqual({ok, #packet_type{msgtype = connect, dup =0, qos = 0, retain = 0}, 128, <<100:1024>>},
-		 (pre_processor:compile_remaining_length(pre_processor:compile_packet_type(<<1:4, 0:4, 128:8, 1:8, 100:1024>>)))).
+		 (pre_processor:interprete_remaining_length(pre_processor:interprete_packet_type(<<1:4, 0:4, 128:8, 1:8, 100:1024>>)))).
 
-%% compile_remaining_length_test - upper limit of the second byte of the remaining length.
-compile_remaining_length_16383_test() ->
+%% interprete_remaining_length_test - upper limit of the second byte of the remaining length.
+interprete_remaining_length_16383_test() ->
     ?assertEqual({ok, #packet_type{msgtype = connect, dup =0, qos = 0, retain = 0}, 16383, <<100:131064>>},
-		 (pre_processor:compile_remaining_length(pre_processor:compile_packet_type(<<1:4, 0:4, 255:8, 127:8, 100:131064>>)))).
+		 (pre_processor:interprete_remaining_length(pre_processor:interprete_packet_type(<<1:4, 0:4, 255:8, 127:8, 100:131064>>)))).
 
-%% compile_remaining_length_test - lower limit of the third byte of the remaining length.
-compile_remaining_length_16384_test() ->
+%% interprete_remaining_length_test - lower limit of the third byte of the remaining length.
+interprete_remaining_length_16384_test() ->
     ?assertEqual({ok, #packet_type{msgtype = connect, dup =0, qos = 0, retain = 0}, 16384, <<100:131072>>},
-		 (pre_processor:compile_remaining_length(pre_processor:compile_packet_type(<<1:4, 0:4, 128:8, 128:8, 1:8, 100:131072>>)))).
+		 (pre_processor:interprete_remaining_length(pre_processor:interprete_packet_type(<<1:4, 0:4, 128:8, 128:8, 1:8, 100:131072>>)))).
 
 
-%% compile_remaining_length_test - upper limit of the third byte of the remaining length.
-compile_remaining_length_2097151_test() ->
+%% interprete_remaining_length_test - upper limit of the third byte of the remaining length.
+interprete_remaining_length_2097151_test() ->
     ?assertEqual({ok, #packet_type{msgtype = connect, dup =0, qos = 0, retain = 0}, 2097151, <<100:16777208>>},
-		 (pre_processor:compile_remaining_length(pre_processor:compile_packet_type(<<1:4, 0:4, 255:8, 255:8, 127:8, 100:16777208>>)))).
+		 (pre_processor:interprete_remaining_length(pre_processor:interprete_packet_type(<<1:4, 0:4, 255:8, 255:8, 127:8, 100:16777208>>)))).
 
-%% compile_remaining_length_test - lower limit of the fourth byte of the remaining length.
-compile_remaining_length_2097152_test() ->
+%% interprete_remaining_length_test - lower limit of the fourth byte of the remaining length.
+interprete_remaining_length_2097152_test() ->
     ?assertEqual({ok, #packet_type{msgtype = connect, dup =0, qos = 0, retain = 0}, 2097152, <<100:16777216>>},
-		 (pre_processor:compile_remaining_length(pre_processor:compile_packet_type(<<1:4, 0:4, 128:8, 128:8, 128:8, 1:8, 100:16777216>>)))).
+		 (pre_processor:interprete_remaining_length(pre_processor:interprete_packet_type(<<1:4, 0:4, 128:8, 128:8, 128:8, 1:8, 100:16777216>>)))).
 
 %%=========================
 %% Note : Following 2 tests are long running tests.
@@ -272,21 +272,21 @@ compile_remaining_length_2097152_test() ->
 %% While they run OK on machines provision by TravisCI.
 %%=========================
 
-%% %% compile_remaining_length_test - upper limit of the fourth byte of the remaining length.
-compile_remaining_length_268435455_test() ->
+%% %% interprete_remaining_length_test - upper limit of the fourth byte of the remaining length.
+interprete_remaining_length_268435455_test() ->
     ?assertEqual({ok, #packet_type{msgtype = connect, dup =0, qos = 0, retain = 0}, 268435455, <<100:2147483640>>},
-		 (pre_processor:compile_remaining_length(pre_processor:compile_packet_type(<<1:4, 0:4, 255:8, 255:8, 255:8, 127:8, 100:2147483640>>)))).
+		 (pre_processor:interprete_remaining_length(pre_processor:interprete_packet_type(<<1:4, 0:4, 255:8, 255:8, 255:8, 127:8, 100:2147483640>>)))).
 
-%% %% compile_remaining_length_test - exceeding the upper limit of the fourth byte of the remaining length.
-compile_remaining_length_268435456_test() ->
+%% %% interprete_remaining_length_test - exceeding the upper limit of the fourth byte of the remaining length.
+interprete_remaining_length_268435456_test() ->
     ?assertEqual({error, remaining_length_exceeds_max_length, {#packet_type{msgtype = connect, dup =0, qos = 0, retain = 0}, <<1:8, 100:2147483648>>}},
-		 (pre_processor:compile_remaining_length(pre_processor:compile_packet_type(<<1:4, 0:4, 128:8, 128:8, 128:8, 128:8, 1:8, 100:2147483648>>)))).
+		 (pre_processor:interprete_remaining_length(pre_processor:interprete_packet_type(<<1:4, 0:4, 128:8, 128:8, 128:8, 128:8, 1:8, 100:2147483648>>)))).
 
 %%=========================
-%% compile packet
+%% interprete packet
 %%=========================
 
-%% compile_remaining_length_test - lower limit of the second byte of the remaining length.
-compile_packet_test() ->
+%% interprete_remaining_length_test - lower limit of the second byte of the remaining length.
+interprete_packet_test() ->
     ?assertEqual({ok, #packet_type{msgtype = publish, dup =0, qos = 0, retain = 0}, 128, <<100:1024>>},
-		 (pre_processor:compile_packet(<<3:4, 0:4, 128:8, 1:8, 100:1024>>))).
+		 (pre_processor:interprete_packet(<<3:4, 0:4, 128:8, 1:8, 100:1024>>))).


### PR DESCRIPTION
What?
Renamed all the functions starting with 'compile'

Why?
The functions are more or less behave like an interpreter,
rather than a compiler. As it doesn't parse entire message at one go.
Instead, it parses message token by token. If anywhere it finds invalid
token, it does not process rest of the message.