### PR TITLE
Implement [MQTT-3.2.2-4]

### DIFF
--- a/src/connack.erl
+++ b/src/connack.erl
@@ -23,8 +23,10 @@
 %% @spec
 %% @end
 %%--------------------------------------------------------------------
-get_pkt({SessionPresent, ReturnCode}) when ReturnCode >= 0, ReturnCode =< 5 ->
-    <<2:4, 0:4, 2:8, 0:7, SessionPresent:1, ReturnCode:8>>.
+get_pkt({SessionPresent, 0}) ->
+    <<2:4, 0:4, 2:8, 0:7, SessionPresent:1, 0:8>>;
+get_pkt({_SessionPresent, ReturnCode}) when ReturnCode >= 0, ReturnCode =< 5 ->
+    <<2:4, 0:4, 2:8, 0:7, 0:1, ReturnCode:8>>.
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================

--- a/test/connack_test.erl
+++ b/test/connack_test.erl
@@ -15,42 +15,42 @@
 get_pkt_1_test() ->
     SessionPresent = 0,
     ReturnCode = 0,
-    ?assertEqual(<<2:4, 0:4, 2:8, 0:7, SessionPresent:1, ReturnCode:8>>,
+    ?assertEqual(<<2:4, 0:4, 2:8, 0:7, SessionPresent:1, 0:8>>,
 		 connack:get_pkt({SessionPresent, ReturnCode})).
 
 get_pkt_2_test() ->
     SessionPresent = 1,
     ReturnCode = 0,
-    ?assertEqual(<<2:4, 0:4, 2:8, 0:7, SessionPresent:1, ReturnCode:8>>,
+    ?assertEqual(<<2:4, 0:4, 2:8, 0:7, SessionPresent:1, 0:8>>,
 		 connack:get_pkt({SessionPresent, ReturnCode})).
 
 get_pkt_3_test() ->
     SessionPresent = 1,
     ReturnCode = 1,
-    ?assertEqual(<<2:4, 0:4, 2:8, 0:7, SessionPresent:1, ReturnCode:8>>,
+    ?assertEqual(<<2:4, 0:4, 2:8, 0:7, 0:1, ReturnCode:8>>,
 		 connack:get_pkt({SessionPresent, ReturnCode})).
 
 get_pkt_4_test() ->
     SessionPresent = 1,
     ReturnCode = 2,
-    ?assertEqual(<<2:4, 0:4, 2:8, 0:7, SessionPresent:1, ReturnCode:8>>,
+    ?assertEqual(<<2:4, 0:4, 2:8, 0:7, 0:1, ReturnCode:8>>,
 		 connack:get_pkt({SessionPresent, ReturnCode})).
 
 get_pkt_5_test() ->
     SessionPresent = 1,
     ReturnCode = 3,
-    ?assertEqual(<<2:4, 0:4, 2:8, 0:7, SessionPresent:1, ReturnCode:8>>,
+    ?assertEqual(<<2:4, 0:4, 2:8, 0:7, 0:1, ReturnCode:8>>,
 		 connack:get_pkt({SessionPresent, ReturnCode})).
 
 get_pkt_6_test() ->
     SessionPresent = 0,
     ReturnCode = 4,
-    ?assertEqual(<<2:4, 0:4, 2:8, 0:7, SessionPresent:1, ReturnCode:8>>,
+    ?assertEqual(<<2:4, 0:4, 2:8, 0:7, 0:1, ReturnCode:8>>,
 		 connack:get_pkt({SessionPresent, ReturnCode})).
 
 get_pkt_7_test() ->
     SessionPresent = 0,
     ReturnCode = 5,
-    ?assertEqual(<<2:4, 0:4, 2:8, 0:7, SessionPresent:1, ReturnCode:8>>,
+    ?assertEqual(<<2:4, 0:4, 2:8, 0:7, 0:1, ReturnCode:8>>,
 		 connack:get_pkt({SessionPresent, ReturnCode})).
 


### PR DESCRIPTION
If a server sends a CONNACK packet containing a non-zero return code it MUST set Session Present to 0 [MQTT-3.2.2-4].